### PR TITLE
fix: remove "companion." from Typewriter words and adjust Navbar styling

### DIFF
--- a/src/app/(main)/page.js
+++ b/src/app/(main)/page.js
@@ -29,7 +29,7 @@ export default function Home() {
               <div className={dmSerifText.className}>
                 <span className="text-[#ff3eb7] font-bold">
                   <Typewriter
-                    words={["student.", "developer.", "companion.", "gamer."]}
+                    words={["student.", "developer.", "gamer."]}
                     cursor={true}
                     cursorStyle="|"
                     cursorBlinking={true}

--- a/src/components/navigation/navbar/index.jsx
+++ b/src/components/navigation/navbar/index.jsx
@@ -13,7 +13,7 @@ import { faListUl } from "@fortawesome/free-solid-svg-icons";
 const Navbar = () => {
   return (
     <>
-      <nav className="backdrop-filter backdrop-blur-lg w-full h-20 sticky top-0 bg-base-100/10 drop-shadow-xl z-50">
+      <nav className="mx-4 mt-4 rounded-box backdrop-filter backdrop-blur-lg h-20 sticky top-0 bg-base-100/10 border border-base-100/40 drop-shadow-xl z-50">
         <div className="container mx-auto px-4 h-full">
           <div className="navbar flex justify-between items-center h-full self-center">
             <LogoBotton />


### PR DESCRIPTION
This pull request makes minor UI updates to the homepage and navigation bar to improve clarity and visual appearance.

Homepage text updates:

* The "Typewriter" effect on the homepage now cycles through "student.", "developer.", and "gamer.", removing "companion." from the list of words.

Navigation bar styling improvements:

* The `<nav>` element in the navigation bar is now styled with margins, rounded corners, and a border for a more polished look.